### PR TITLE
Configure Wisp compiler from Webpack config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path');
-var wisp_compiler = require('wisp/compiler'); 
+var wisp_compiler = require('wisp/compiler');
+var loaderUtils = require("loader-utils");
 
 module.exports = function(source) {
     this.cacheable();
@@ -7,7 +8,10 @@ module.exports = function(source) {
     // This is done to avoid having to mess with the `require()` calls in your code
     this.options.resolve.extensions.push('.wisp');
 
-    var result = wisp_compiler.compile(source, { 'source-uri': this.resourcePath });
+    var query = this.query instanceof Object ? this.query : loaderUtils.parseQuery(this.query);
+    query['source-uri'] =  this.resourcePath;
+
+    var result = wisp_compiler.compile(source, query);
 
     if ('error' in result) {
         // TODO: We really need to pull the string in a slightly nicer way

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/girvo/wisp-loader"
+  },
+  "dependencies": {
+    "loader-utils": "^0.2.12"
   }
 }


### PR DESCRIPTION
Thanks for this plugin :)

I wanted to be able to turn off the generation of source maps, so I added this. Now you can do:

```
loaders: [{
  test: /\.wisp$/,
  loader: "wisp-loader?no-map"
}]
```

Or:

```
loaders: [{
  test: /\.wisp$/,
  loader: "wisp-loader",
  query: { "no-map": true }
}]
```

Let me know if you have any issues with this,
Matt
